### PR TITLE
v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+
+## [2022-06-27] v0.1.3
+
+- 898c179 docs: v0.1.3
+- 567aa39 chore: more exact RegExp
+- 32ac54d refactor: `options.dynamic` instead of `options.depth`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Like Webpack's require
 
 English | [简体中文](https://github.com/vite-plugin/vite-require/blob/main/README.zh-CN.md)
 
-✅ dynamic-require `require('./foo/' + bar)`  
+✅ dynamic-require similar to 👉 [Webpack](https://webpack.js.org/guides/dependency-management/#require-with-expression) `require('./foo/' + bar)`
+
+📦 Out of the box  
+
+🔨 Work only in the `vite serve` phase  
 
 ## Install
 
@@ -34,10 +38,13 @@ viteRequire([options])
 export interface Options {
   extensions?: string[]
   filter?: (id: string) => false | void
-  /**
-   * When use the dynamic-require, this option will change `./*` to `./** /*`
-   * @default true
-   */
-  depth?: boolean
+  dynamic?: {
+    /**
+     * 1. `true` - Match all possibilities as much as possible, More like `webpack`
+     * 2. `false` - It behaves more like `@rollup/plugin-dynamic-import-vars`
+     * @default true
+     */
+    loose?: boolean
+  }
 }
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,12 @@
 
 [English](https://github.com/vite-plugin/vite-require#readme) | 简体中文
 
-✅ dynamic-require `require('./foo/' + bar)`  
+✅ dynamic-require 和 👉 [Webpack](https://webpack.js.org/guides/dependency-management/#require-with-expression) `require('./foo/' + bar)`类似
+
+📦 开箱即用
+
+🔨 只在 `vite serve` 阶段起作用 
+
 
 ## 安装
 
@@ -34,10 +39,13 @@ viteRequire([options])
 export interface Options {
   extensions?: string[]
   filter?: (id: string) => false | void
-  /**
-   * When use the dynamic-require, this option will change `./*` to `./** /*`
-   * @default true
-   */
-  depth?: boolean
+  dynamic?: {
+    /**
+     * 1. `true` - Match all possibilities as much as possible, More like `webpack`
+     * 2. `false` - It behaves more like `@rollup/plugin-dynamic-import-vars`
+     * @default true
+     */
+    loose?: boolean
+  }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-require",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Like Webpack's require",
   "main": "dist/index.js",
   "repository": {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -90,6 +90,7 @@ function findTopLevelScope(ancestors: AcornNode[]): AcornNode {
     return arr.find(e => e.type === TopScopeType.ExpressionStatement)
   }
 
+  // At present, "ancestors" contains only one depth of "MemberExpression"
   if (/Program,VariableDeclaration,VariableDeclarator,(MemberExpression,)?CallExpression$/.test(ances)) {
     // const bar = require('foo').bar
     // const { foo, bar: baz } = require('foo')

--- a/src/dynamic-require.ts
+++ b/src/dynamic-require.ts
@@ -173,7 +173,7 @@ export class DynamicRequire {
         if (!glob) return
 
         glob = tryFixGlobSlash(glob)
-        this.options.depth !== false && (glob = toDepthGlob(glob))
+        this.options.dynamic?.loose !== false && (glob = toDepthGlob(glob))
 
         let fileGlob: string
         if (glob.endsWith(this.EXT)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,14 @@ import { DynamicRequire } from './dynamic-require'
 export interface Options {
   extensions?: string[]
   filter?: (id: string) => false | void
-  /**
-   * When use the dynamic-require, this option will change `./*` to `./** /*`
-   * @default true
-   */
-  depth?: boolean
+  dynamic?: {
+    /**
+     * 1. `true` - Match all possibilities as much as possible, More like `webpack`
+     * 2. `false` - It behaves more like `@rollup/plugin-dynamic-import-vars`
+     * @default true
+     */
+    loose?: boolean
+  }
 }
 
 export function viteRequire(options: Options = {}): Plugin {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export function viteRequire(options: Options = {}): Plugin {
     transform(code, id) {
       const pureId = cleanUrl(id)
 
-      if (/node_modules\/(?!\.vite)/.test(pureId)) return
+      if (/node_modules\/(?!\.vite\/)/.test(pureId)) return
       if (!extensions.includes(path.extname(pureId))) return
       if (!isCommonjs(code)) return
       if (options.filter?.(pureId) === false) return


### PR DESCRIPTION
- [refactor: options.dynamic instead of options.depth](https://github.com/vite-plugin/vite-require/commit/32ac54d97f229c39cb15b3856f62a9fdd3682762)
- [chore: more exact RegExp](https://github.com/vite-plugin/vite-require/commit/567aa391c24696aca0647bbf2913938ded6f5e5e)