### PR TITLE
版本存在两个问题

### DIFF
--- a/src/dynamic-require.ts
+++ b/src/dynamic-require.ts
@@ -225,8 +225,11 @@ export class DynamicRequire {
         // TODO: execute the Options.onFiles
 
         if (!files.length) continue
-
-        const maps = mappingPath(files, resolved)
+        const mapAlias = resolved
+            ? { [resolved.alias.relative]: resolved.alias.findString }
+            : undefined
+        // @ts-ignore
+        const maps = mappingPath(files, mapAlias)
         const runtimeFnName = `__matchRequireRuntime${counter}__`
         let counter2 = 0
         const cases: string[] = []


### PR DESCRIPTION
1、当存在alias存在时, mappingPath方法使用了Object.entries(alias)[0]的方式获取需要改造新的处理方式
2、当前filter不满足vue场景下, vite会携带参数请求js/css等文件, 当前filter会出去参数, 无法判断的问题，更换vite提供的createFilter创建过滤器，类似vite-plugin-jsx的配置方式